### PR TITLE
fix setEnabled() method

### DIFF
--- a/TimedEvents/src/org/multiply/processing/TimedEventGenerator.java
+++ b/TimedEvents/src/org/multiply/processing/TimedEventGenerator.java
@@ -137,6 +137,9 @@ public class TimedEventGenerator {
    * @param isEnabled whether or not the timer event will fire in the parent sketch.
    */
   public void setEnabled(boolean isEnabled) {
+    if (this.isEnabled == isEnabled) {
+      return;
+    }
     if (this.isEnabled) {
       cancelTask();
     } else {


### PR DESCRIPTION
when calling setEnabled(false) twice in a row it causes task to be scheduled however no actions should be taken